### PR TITLE
Added object support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ If everything goes well, you will find a wgt file in the `build` folder.
 ## Settings
 
 - `Recording by default`: Whether the widget starts on recording or playing mode.
+- `Keep events on send`: If events should be keeped when they are sent while on recording mode. If set, to get the next event the drop button must be used.
 
 ## Wiring
 

--- a/README.md
+++ b/README.md
@@ -41,27 +41,26 @@ If everything goes well, you will find a wgt file in the `build` folder.
 
 ## Settings
 
-`Write here the preferences`
+- `Allow send data`: If this preference is set to true, the widget enters the "allow-send mode" where new events can be created and sent events won't be destroyed.
 
 ## Wiring
 
-
 ### Input Endpoints
 
-`Write here the input wiring endpoints`
-
+- `Input`: The data to be analyzed.
 
 ### Output Endpoints
 
-
-`Write here the output wiring endpoints`
+- `Output`: The endpoint where the received data will be sent.
 
 ## Usage
 
+Plug in the output endpoint you want to spy and it will be displayed on the widget.
+If the record mode is activated, data won't be sent forward until the step or run buttons are pressed. While on this mode, data can be edited and the modified data will be sent instead.
 
-## Reference
+If the `Allow send data` preference is set to true, new events can be created through the widget. While on this mode captured events can also be edited. Sent events while on this mode won't be deleted until the drop button is pressed.
 
-- [FIWARE Mashup](https://mashup.lab.fiware.org/)
+The output data will be sent with the type defined by the type selector.
 
 ## Copyright and License
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ If everything goes well, you will find a wgt file in the `build` folder.
 ## Settings
 
 - `Recording by default`: Whether the widget starts on recording or playing mode.
-- `Keep events on send`: If events should be keeped when they are sent while on recording mode. If set, to get the next event the drop button must be used.
 
 ## Wiring
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ grunt
 
 If everything goes well, you will find a wgt file in the `build` folder.
 
+## Settings
+
+- `Recording by default`: Whether the widget starts on recording or playing mode.
+
 ## Wiring
 
 ### Input Endpoints

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ If everything goes well, you will find a wgt file in the `build` folder.
 
 ## Usage
 
+## Usage
+
 Plug in the output endpoint you want to spy and it will be displayed on the widget.
 If the record mode is activated, data won't be sent forward until the step or run buttons are pressed. While on this mode, data can be edited and the modified data will be sent instead.
-
-If the `Allow send data` preference is set to true, new events can be created through the widget. While on this mode captured events can also be edited. Sent events while on this mode won't be deleted until the drop button is pressed.
 
 The output data will be sent with the type defined by the type selector.
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ Spy Wiring widget
 
 The Spy Wiring widget is a WireCloud widget that provides an easy way to inspect the data that travels trough the wiring.
 
-Latest version of this widget is always [provided in FIWARE lab](https://store.lab.fiware.org/search/keyword/KurentoStarterKit) where you can make use of it on the [Mashup portal](https://mashup.lab.fiware.org/)
-
 Build
 -----
 
@@ -38,10 +36,6 @@ grunt
 ```
 
 If everything goes well, you will find a wgt file in the `build` folder.
-
-## Settings
-
-- `Allow send data`: If this preference is set to true, the widget enters the "allow-send mode" where new events can be created and sent events won't be destroyed.
 
 ## Wiring
 

--- a/src/config.xml
+++ b/src/config.xml
@@ -22,6 +22,9 @@
     <inputendpoint name="textinput" type="text" label="Input" description="Data to be analyzed" friendcode="*"/>
     <outputendpoint name="textoutput" type="text" label="Output" description="" friendcode="*"/>
   </wiring>
+  <preferences>
+    <preference name="recording" label="Recording by default" description="Start the widget in recording mode" type="boolean" default="false"/>
+  </preferences>
   <contents src="index.html" useplatformstyle="true"/>
   <rendering height="470px" width="25%"/>
 </widget>

--- a/src/config.xml
+++ b/src/config.xml
@@ -24,6 +24,7 @@
   </wiring>
   <preferences>
     <preference name="recording" label="Recording by default" description="Start the widget in recording mode" type="boolean" default="false"/>
+    <preference name="keep-events" label="Keep events on send" description="If events should be keeped when they are sent while on recording mode. If set, to get the next event the drop button must be used" type="boolean" default="false"/>
   </preferences>
   <contents src="index.html" useplatformstyle="true"/>
   <rendering height="470px" width="25%"/>

--- a/src/config.xml
+++ b/src/config.xml
@@ -24,7 +24,6 @@
   </wiring>
   <preferences>
     <preference name="recording" label="Recording by default" description="Start the widget in recording mode" type="boolean" default="false"/>
-    <preference name="keep-events" label="Keep events on send" description="If events should be keeped when they are sent while on recording mode. If set, to get the next event the drop button must be used" type="boolean" default="false"/>
   </preferences>
   <contents src="index.html" useplatformstyle="true"/>
   <rendering height="470px" width="25%"/>

--- a/src/config.xml
+++ b/src/config.xml
@@ -19,8 +19,8 @@
       <feature name="StyledElements"/>
   </requirements>
   <wiring>
-    <inputendpoint name="textinput" type="text" label="Text Input" description="" friendcode="*"/>
-    <outputendpoint name="textoutput" type="text" label="Text output" description="" friendcode="*"/>
+    <inputendpoint name="textinput" type="text" label="Input" description="Data to be analyzed" friendcode="*"/>
+    <outputendpoint name="textoutput" type="text" label="Output" description="" friendcode="*"/>
   </wiring>
   <preferences>
     <preference name="allowsend" label="Allow send data" description="Allow send data without receiving it" type="boolean" default="false"/>

--- a/src/config.xml
+++ b/src/config.xml
@@ -22,9 +22,6 @@
     <inputendpoint name="textinput" type="text" label="Input" description="Data to be analyzed" friendcode="*"/>
     <outputendpoint name="textoutput" type="text" label="Output" description="" friendcode="*"/>
   </wiring>
-  <preferences>
-    <preference name="allowsend" label="Allow send data" description="Allow send data without receiving it" type="boolean" default="false"/>
-  </preferences>
   <contents src="index.html" useplatformstyle="true"/>
   <rendering height="470px" width="25%"/>
 </widget>

--- a/src/doc/changelog.md
+++ b/src/doc/changelog.md
@@ -6,7 +6,7 @@ vX.X.X
 - Removed the allowsend preference.
 - Added create event button to create new events.
 - Added `Recording by default` preference to start the widget in recording mode.
-- Added `Keep events on send` preference to keep events after being sent.
+- Added send and keep event button.
 - Fixed drop button dropping the last received event instead of the current event.
 - Fixed record/play button being disabled after toggling off the allowsend preference.
 

--- a/src/doc/changelog.md
+++ b/src/doc/changelog.md
@@ -3,8 +3,10 @@ vX.X.X
 
 - Supports object events.
 - Dropdown selector to choose the output data type.
-- Allowsend mode always stores the current event instead of waiting until there are none left.
-- Allowsend mode now works with the drop button to loop through the events.
+- Removed the allowsend preference.
+- Added create event button to create new events.
+- Added `Recording by default` preference to start the widget in recording mode.
+- Added `Keep events on send` preference to keep events after being sent.
 - Fixed drop button dropping the last received event instead of the current event.
 - Fixed record/play button being disabled after toggling off the allowsend preference.
 

--- a/src/doc/changelog.md
+++ b/src/doc/changelog.md
@@ -1,3 +1,13 @@
+vX.X.X
+======
+
+- Supports object events.
+- Dropdown selector to choose the output data type.
+- Allowsend mode always stores the current event instead of waiting until there are none left.
+- Allowsend mode now works with the drop button to loop through the events.
+- Fixed drop button dropping the last received event instead of the current event.
+- Fixed record/play button being disabled after toggling off the allowsend preference.
+
 v1.0.2
 ======
 

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -2,12 +2,6 @@
 
 The Spy Wiring widget is a WireCloud widget that provides an easy way to inspect the data that travels trough the wiring.
 
-Latest version of this widget is always [provided in FIWARE lab](https://store.lab.fiware.org/search/keyword/KurentoStarterKit) where you can make use of it on the [Mashup portal](https://mashup.lab.fiware.org/)
-
-## Settings
-
-- `Allow send data`: If this preference is set to true, the widget enters the "allow-send mode" where new events can be created and sent events won't be destroyed.
-
 ## Wiring
 
 ### Input Endpoints

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -15,7 +15,6 @@ The Spy Wiring widget is a WireCloud widget that provides an easy way to inspect
 ## Settings
 
 - `Recording by default`: Whether the widget starts on recording or playing mode.
-- `Keep events on send`: If events should be keeped when they are sent while on recording mode. If set, to get the next event the drop button must be used.
 
 ## Usage
 

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -12,6 +12,10 @@ The Spy Wiring widget is a WireCloud widget that provides an easy way to inspect
 
 - `Output`: The endpoint where the received data and new events will be sent.
 
+## Settings
+
+- `Recording by default`: Whether the widget starts on recording or playing mode.
+
 ## Usage
 
 Plug in the output endpoint you want to spy and it will be displayed on the widget.

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -1,19 +1,31 @@
 ## Introduction
 
+The Spy Wiring widget is a WireCloud widget that provides an easy way to inspect the data that travels trough the wiring.
+
+Latest version of this widget is always [provided in FIWARE lab](https://store.lab.fiware.org/search/keyword/KurentoStarterKit) where you can make use of it on the [Mashup portal](https://mashup.lab.fiware.org/)
 
 ## Settings
+
+- `Allow send data`: If this preference is set to true, the widget enters the "allow-send mode" where new events can be created and sent events won't be destroyed.
 
 ## Wiring
 
 ### Input Endpoints
 
+- `Input`: The data to be analyzed.
+
 ### Output Endpoints
+
+- `Output`: The endpoint where the received data and new events will be sent.
 
 ## Usage
 
-## Reference
+Plug in the output endpoint you want to spy and it will be displayed on the widget.
+If the record mode is activated, data won't be sent forward until the step or run buttons are pressed. While on this mode, data can be edited and the modified data will be sent instead.
 
-- [FIWARE Mashup](https://mashup.lab.fiware.org/)
+If the `Allow send data` preference is set to true, new events can be created through the widget. While on this mode captured events can also be edited. Sent events while on this mode won't be deleted until the drop button is pressed.
+
+The output data will be sent with the type defined by the type selector.
 
 ## Copyright and License
 

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -15,6 +15,7 @@ The Spy Wiring widget is a WireCloud widget that provides an easy way to inspect
 ## Settings
 
 - `Recording by default`: Whether the widget starts on recording or playing mode.
+- `Keep events on send`: If events should be keeped when they are sent while on recording mode. If set, to get the next event the drop button must be used.
 
 ## Usage
 

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -17,8 +17,6 @@ The Spy Wiring widget is a WireCloud widget that provides an easy way to inspect
 Plug in the output endpoint you want to spy and it will be displayed on the widget.
 If the record mode is activated, data won't be sent forward until the step or run buttons are pressed. While on this mode, data can be edited and the modified data will be sent instead.
 
-If the `Allow send data` preference is set to true, new events can be created through the widget. While on this mode captured events can also be edited. Sent events while on this mode won't be deleted until the drop button is pressed.
-
 The output data will be sent with the type defined by the type selector.
 
 ## Copyright and License

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -165,7 +165,7 @@
                 editor.setText(d);
             }
         } else {
-            parse_json(d, "JSON - Object)");
+            parse_json(d, "JSON - (Object)");
         }
     };
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -88,10 +88,14 @@
         layout.getCenterContainer().addClassName('jsoncontainer');
         editor = new JSONEditor(layout.getCenterContainer().wrapperElement, options);
 
-        updateContent('No data');
+        //Create loading animation
+        layout.getCenterContainer().addClassName('loading');
+        layout.getCenterContainer().disable();
+
+        editor.setMode("text");
+        editor.setText('');
 
         layout.repaint();
-
 
         MP.wiring.registerCallback('textinput', function (data) {
             updateContent(data);
@@ -162,13 +166,19 @@
     };
 
     var clearEvents = function clearEvents() {
-        updateType('No data');
         editor.options.modes = ['text'];
         editor.setMode('text');
-        editor.setText('No data');
+        editor.setText('');
+        // Add the loading animation
+        layout.getCenterContainer().disable();
+        stack = [];
+        updateStackInfo();
     };
 
     var updateContent = function updateContent(d) {
+        // Remove the loading animation
+        layout.getCenterContainer().enable();
+
         if (recording) {
             stack.unshift(d);
             var n = parseInt(stack_n.textContent) + 1;
@@ -206,20 +216,20 @@
             }
 
             // Update the editor contents to view the next data
-            var next = 'No data';
+            var next;
             if (stack.length > 0) {
                 next = stack[stack.length - 1];
             } else if (allowsend) {
                 next = data;
                 stack.push(data);
+            } else {
+                clearEvents();
+                return;
             }
             updateStackInfo();
             parse_data(next);
         }
-
-        if (data !== "No data") {
-            MP.wiring.pushEvent(output, data);
-        }
+        MP.wiring.pushEvent(output, data);
     };
 
     var change_class = function (elem, c1, c2) {
@@ -245,12 +255,11 @@
         change_class(playbtn, 'btn-success', 'btn-danger');
         run_action();
         playbtn.setTitle('Start recording events');
-        parse_data('No data');
         setdisable_btns(true);
     };
 
     var pause_proxy = function () {
-        parse_data('No data');
+        clearEvents ();
         recording = true;
         change_class(playbtn, 'icon-circle', 'icon-stop');
         change_class(playbtn, 'btn-danger', 'btn-success');
@@ -277,16 +286,17 @@
         sendData(TEXT);
     };
 
-
     var drop_action = function () {
         if (stack.length > 0) {
             stack.shift();
-            var next = 'No data';
+            var next;
             if (stack.length > 0) {
                 next = stack[stack.length - 1];
+                updateStackInfo();
+                parse_data(next);
+            } else {
+                clearEvents();
             }
-            updateStackInfo();
-            parse_data(next);
         }
     };
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -169,8 +169,11 @@
         editor.options.modes = ['text'];
         editor.setMode('text');
         editor.setText('');
-        // Add the loading animation
-        layout.getCenterContainer().disable();
+        // Add the loading animation.
+        // If allow send is enabled means the last event was dropped, but you are still on editor mode.
+        if (!allowsend)  {
+            layout.getCenterContainer().disable();
+        }
         stack = [];
         updateStackInfo();
     };
@@ -215,13 +218,17 @@
                 data = editordata;
             }
 
+            // If on send mode, send the data without updating view
+            if (allowsend) {
+                stack.push(data);
+                MP.wiring.pushEvent(output, data);
+                return;
+            }
+
             // Update the editor contents to view the next data
             var next;
             if (stack.length > 0) {
                 next = stack[stack.length - 1];
-            } else if (allowsend) {
-                next = data;
-                stack.push(data);
             } else {
                 clearEvents();
                 return;
@@ -244,7 +251,7 @@
         if (allowsend) {
             playbtn.setDisabled(true);
             runbtn.setDisabled(true);
-            dropbtn.setDisabled(true);
+            dropbtn.setDisabled(false);
             stepbtn.setDisabled(false);
         }
     };
@@ -288,7 +295,7 @@
 
     var drop_action = function () {
         if (stack.length > 0) {
-            stack.shift();
+            stack.pop();
             var next;
             if (stack.length > 0) {
                 next = stack[stack.length - 1];

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -37,7 +37,7 @@
 
     var stack = [];
 
-    var select;
+    var typeSelector;
 
     var init = function init () {
         layout = new StyledElements.BorderLayout();
@@ -51,7 +51,7 @@
         var parent = typed.parentNode;
         parent.removeChild(typed);
         createTypeSelectors();
-        select.insertInto(parent);
+        typeSelector.insertInto(parent);
 
         // Create the remaining events count
         stack_n = document.createElement('div');
@@ -88,8 +88,6 @@
         layout.getCenterContainer().addClassName('jsoncontainer');
         editor = new JSONEditor(layout.getCenterContainer().wrapperElement, options);
 
-
-
         updateContent('No data');
 
         layout.repaint();
@@ -112,12 +110,12 @@
 
     // Sets a value for the data-type selector
     var updateType = function updateType(type) {
-        select.setValue(type);
+        typeSelector.setValue(type);
     };
 
-    //Create the selectors to choose the type of the output data
+    //Create the selector to choose the type of the output data
     var createTypeSelectors = function createTypeSelectors () {
-        select = new StyledElements.Select();
+        typeSelector = new StyledElements.Select();
 
         var entries = [
             {label: "JSON - (Text)", value: "JSON - (Text)"},
@@ -125,11 +123,8 @@
             {label: "Text", value: "Text"}
         ];
 
-        select.addEntries(entries);
-        select.setValue("JSON - (Text)");
-
-        return select;
-
+        typeSelector.addEntries(entries);
+        typeSelector.setValue("JSON - (Text)");
     };
 
     var parse_json = function parse_json(json, type) {
@@ -193,15 +188,24 @@
         setdisable_btns(stack.length === 0);
     };
 
-    var sendData = function (type, data) {
+    var sendData = function (output, data) {
+        // Data is undefined if it was called by the step / play events
         if (typeof data === "undefined") {
-            var editordata = editor.getText();
+            // Get the selected data type.
+            var editordata;
+            if (typeSelector.getValue() === "JSON - (Object)") {
+                editordata = editor.get(); // Object
+            } else {
+                editordata = editor.getText(); //JSON string / string
+            }
+
             data = stack.pop();
 
             if (data !== editordata) {
                 data = editordata;
             }
 
+            // Update the editor contents to view the next data
             var next = 'No data';
             if (stack.length > 0) {
                 next = stack[stack.length - 1];
@@ -214,7 +218,7 @@
         }
 
         if (data !== "No data") {
-            MP.wiring.pushEvent(type, data);
+            MP.wiring.pushEvent(output, data);
         }
     };
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -44,7 +44,6 @@
         layout.getNorthContainer().addClassName('header');
         layout.getNorthContainer().wrapperElement.innerHTML = '<h4 class="text-primary">Type: <span id="type-data">No data</span></h4><div id="buttons"></div>';
 
-
         // Create the data-type selector
         var typed = $("#type-data")[0];
         var parent = typed.parentNode;
@@ -97,6 +96,12 @@
 
         editor.setMode("text");
         editor.setText('');
+
+        // Check if it has to be on recording mode
+        recording = MP.prefs.get("recording");
+        if (recording) {
+            pause_proxy();
+        }
 
         layout.repaint();
 
@@ -160,7 +165,7 @@
                 editor.setText(d);
             }
         } else {
-            parse_json(d, "JSON - (Object)");
+            parse_json(d, "JSON - Object)");
         }
     };
 
@@ -218,7 +223,7 @@
                 data = editordata;
             }
 
-            // If on send mode, send the data without updating view
+            // Keep sent event on the editor.
             if (false) { //TODO
                 stack.push(data);
                 MP.wiring.pushEvent(output, data);

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -38,6 +38,8 @@
 
     var typeSelector;
 
+    var keepEvents;
+
     var init = function init () {
         layout = new StyledElements.BorderLayout();
         layout.insertInto(document.body);
@@ -102,6 +104,12 @@
         if (recording) {
             pause_proxy();
         }
+
+
+        MP.prefs.registerCallback(function (prefs) {
+            keepEvents = MP.prefs.get("keep-events");
+        });
+        keepEvents = MP.prefs.get("keep-events");
 
         layout.repaint();
 
@@ -224,7 +232,7 @@
             }
 
             // Keep sent event on the editor.
-            if (false) { //TODO
+            if (keepEvents) { //TODO
                 stack.push(data);
                 MP.wiring.pushEvent(output, data);
                 return;

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -223,18 +223,15 @@
                 stack.push(data);
                 MP.wiring.pushEvent(output, data);
                 return;
-            }
-
-            // Update the editor contents to view the next data
-            var next;
-            if (stack.length > 0) {
-                next = stack[stack.length - 1];
+            } else if (stack.length > 0) {
+                // Update the editor contents to view the next data
+                var next = stack[stack.length - 1];
+                updateStackInfo();
+                parse_data(next);
             } else {
+                // No events left
                 clearEvents();
-                return;
             }
-            updateStackInfo();
-            parse_data(next);
         }
         MP.wiring.pushEvent(output, data);
     };

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -108,6 +108,7 @@
 
         MP.prefs.registerCallback(function (prefs) {
             keepEvents = MP.prefs.get("keep-events");
+            setdisable_btns(stack.length === 0);
         });
         keepEvents = MP.prefs.get("keep-events");
 
@@ -256,7 +257,7 @@
     };
 
     var setdisable_btns = function (value) {
-        runbtn.setDisabled(value);
+        runbtn.setDisabled(value || keepEvents);
         stepbtn.setDisabled(value);
         dropbtn.setDisabled(value);
     };

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -24,7 +24,7 @@
     var layout;
     var stack_n;
 
-    var createbtn, playbtn, runbtn, stepbtn, dropbtn;
+    var createbtn, playbtn, runbtn, stepbtn, sendbtn, dropbtn;
 
     var recording = false;
 
@@ -37,8 +37,6 @@
     var stack = [];
 
     var typeSelector;
-
-    var keepEvents;
 
     var init = function init () {
         layout = new StyledElements.BorderLayout();
@@ -60,20 +58,25 @@
         stack_n.textContent = '0';
 
         // Create and bind action buttons
-        createbtn = new StyledElements.StyledButton({'class': 'btn-info icon-file', 'title': 'Create new event'});
+        createbtn = new StyledElements.StyledButton({'class': 'btn-info fa fa-plus', 'title': 'Create new event'});
         createbtn.insertInto(document.getElementById('buttons'));
         createbtn.addEventListener("click", create_action);
 
-        playbtn = new StyledElements.StyledButton({'class': 'btn-danger icon-circle', 'title': 'Start recording events'});
+        playbtn = new StyledElements.StyledButton({'class': 'btn-danger fa fa-circle', 'title': 'Start recording events'});
         playbtn.insertInto(document.getElementById('buttons'));
         playbtn.addEventListener("click", play_action);
-        runbtn = new StyledElements.StyledButton({'class': 'btn-info icon-fast-forward', 'title': 'Launch all pending events'});
+        runbtn = new StyledElements.StyledButton({'class': 'btn-info fa fa-fast-forward', 'title': 'Launch all pending events'});
         runbtn.insertInto(document.getElementById('buttons'));
         runbtn.addEventListener('click', run_action);
-        stepbtn = new StyledElements.StyledButton({'class': 'btn-info icon-step-forward', 'title': 'Launch current event'});
+        stepbtn = new StyledElements.StyledButton({'class': 'btn-info fa fa-step-forward', 'title': 'Launch current event'});
         stepbtn.insertInto(document.getElementById('buttons'));
         stepbtn.addEventListener('click', step_action);
-        dropbtn = new StyledElements.StyledButton({'class': 'btn-info icon-trash', 'title': 'Drop current event'});
+
+        sendbtn = new StyledElements.StyledButton({'class': 'btn-info fa fa-play', 'title': 'Launch and keep current event'});
+        sendbtn.insertInto(document.getElementById('buttons'));
+        sendbtn.addEventListener('click', send_action);
+
+        dropbtn = new StyledElements.StyledButton({'class': 'btn-info fa fa-trash', 'title': 'Drop current event'});
         dropbtn.insertInto(document.getElementById('buttons'));
         dropbtn.addEventListener('click', drop_action);
         // Disable the buttons
@@ -104,13 +107,6 @@
         if (recording) {
             pause_proxy();
         }
-
-
-        MP.prefs.registerCallback(function (prefs) {
-            keepEvents = MP.prefs.get("keep-events");
-            setdisable_btns(stack.length === 0);
-        });
-        keepEvents = MP.prefs.get("keep-events");
 
         layout.repaint();
 
@@ -215,7 +211,7 @@
         setdisable_btns(stack.length === 0);
     };
 
-    var sendData = function (output, data) {
+    var sendData = function (output, data, keepEvents) {
         // Data is undefined if it was called by the step / play events
         if (typeof data === "undefined") {
             // Get the selected data type.
@@ -257,8 +253,9 @@
     };
 
     var setdisable_btns = function (value) {
-        runbtn.setDisabled(value || keepEvents);
+        runbtn.setDisabled(value);
         stepbtn.setDisabled(value);
+        sendbtn.setDisabled(value);
         dropbtn.setDisabled(value);
     };
 
@@ -297,6 +294,10 @@
 
     var step_action = function () {
         sendData(TEXT);
+    };
+
+    var send_action = function () {
+        sendData(TEXT, undefined, true);
     };
 
     var drop_action = function () {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -70,7 +70,11 @@
     var parse_json = function parse_json(json, type) {
         editor.options.modes = modes;
         editor.set(json);
-        if (editor.options.mode === "text") {
+
+        if (editor.options.mode === "tree") {
+            editor.setMode("text"); //Force the editor to refresh, since if its already on tree mode it gets bugged (lol)
+            editor.setMode("tree");
+        } else if (editor.options.mode === "text") {
             editor.setMode("tree");
         }
         if (editor.options.mode !== 'code') {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -191,6 +191,7 @@
             }
             setdisable_btns(false);
         } else {
+            stack = [d];
             parse_data(d);
         }
     };
@@ -257,8 +258,8 @@
     };
 
     var pause_proxy = function () {
-        clearEvents (); //TODO
         recording = true;
+        updateStackInfo(); // There might be an event on the editor before going into record mode.
         change_class(playbtn, 'icon-circle', 'icon-stop');
         change_class(playbtn, 'btn-danger', 'btn-success');
         playbtn.setTitle('Stop recording events (Launch all pending events)');

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -301,6 +301,7 @@
             } else {
                 drop_action();
                 play_proxy();
+                playbtn.setDisabled(false);
             }
         }
     };


### PR DESCRIPTION
# Changelog: 
- Init function with all the scattered statements that setup the widget.
- Supports object events.
- Dropdown selector to choose the output data type.
- Removed the allowsend preference.
- Added create event button to create new events.
- Added `Recording by default` preference to start the widget in recording mode.
- Added `Keep events on send` preference to keep events after being sent.
- Fixed drop button dropping the last received event instead of the current event.
- Fixed record/play button being disabled after toggling off the allowsend preference.
- Fixed only showing the first object (This looks like a bug of jsoneditor).
